### PR TITLE
fix css/sitemap.css include

### DIFF
--- a/_sitemap/xsl.njk
+++ b/_sitemap/xsl.njk
@@ -46,7 +46,7 @@ eleventyExcludeFromCollections: true
             {% include "css/typography.css" %}
             {% include "css/link.css" %}
             {% include "css/theme.css" %}
-            {% include "css/sitemap.css" %}
+            {# {% include "css/sitemap.css" %} #}
           ]]>
         </style>
       </head>


### PR DESCRIPTION
this fixes an include for `css/sitemap.css`. 
created an empty file in the `_includes` folder